### PR TITLE
Add a second-based timestamp to messages going into the broker

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,6 +136,8 @@ Remit.prototype.req = function req (event, args, callback, options, caller) {
     options.headers = options.headers || {}
     options.headers.uuid = uuid()
 
+    options.timestamp = Math.ceil(+new Date() / 1000)
+
     self.__connect(() => {
         self.__assert_exchange(() => {
             if (!callback) {


### PR DESCRIPTION
There's a RabbitMQ plugin that provides this, but it's quite nice to have it included within Remit.