### PR TITLE
Work channel pooling

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const os = require('os')
 const uuid = require('uuid').v4
 const trace = require('stack-trace')
 const amqplib = require('amqplib/callback_api')
+const Pool = require('pool2')
 
 module.exports = function (opts) {
     return new Remit(opts)

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "amqplib": "^0.4.2",
     "debug": "^2.6.0",
+    "pool2": "^1.4.1",
     "stack-trace": "0.0.9",
     "uuid": "^3.0.1"
   },


### PR DESCRIPTION
With the previous system, a single work channel was being used to serve all requests. Worker channels within _remit_ are mainly used to check for the existence of a consumer when replying to a request. If the consumer is no longer present, the worker channel dies and a new one must be made.

As these were being created on-demand, repeated messages with no consumer brought the entire system to a crawl, processing tens of messages a second rather than thousands (in our production system, this was causing some messages to time out as a result).

With the introduction of this cheeky worker pool, we should be back up and running as normal.
Tested with up to 1,000,000 messages with mixes of consumers available, alternating good and bad messages and all sorts. Seems to be working well even in this basic state.