### PR TITLE
⚡️ Set TCP_NODELAY (disable Nagle's algorithm)

### DIFF
--- a/utils/generateConnectionOptions.js
+++ b/utils/generateConnectionOptions.js
@@ -3,6 +3,7 @@ const packageJson = require('../package.json')
 
 function generateConnectionOptions (name) {
   return {
+    noDelay: true,
     clientProperties: {
       connection_name: name,
       powered_by: `${packageJson.name}@${packageJson.version} (${packageJson.repository.url.substr(0, packageJson.repository.url.length - 4)}/tree/${packageJson.version})`,


### PR DESCRIPTION
#21 has shown that `noDelay: true` _does_ help speed. That issue's still being investigated in regards to speed issues, but [other clients](https://github.com/pika/pika/blob/5ceaef10cd96f82479226a93ec0bf8291fa731bf/pika/adapters/base_connection.py#L204) already disable Nagle's algorithm by default, so it's looking like a good choice regardless.