### PR TITLE
🌈 Allow connections to AMQPS URLs

### DIFF
--- a/lib/Remit.js
+++ b/lib/Remit.js
@@ -1,3 +1,4 @@
+const url = require('url')
 const amqplib = require('amqplib')
 const EventEmitter = require('eventemitter3')
 const packageJson = require('../package.json')
@@ -40,6 +41,8 @@ class Remit {
   async _connect ({ url, name, exchange }) {
     const amqpUrl = parseAmqpUrl(url)
     const connectionOptions = generateConnectionOptions(name)
+    const { hostname } = url.parse(amqpUrl)
+    connectionOptions.servername = hostname
     const connection = await amqplib.connect(amqpUrl, connectionOptions)
 
     const tempChannel = await connection.createChannel()

--- a/lib/Remit.js
+++ b/lib/Remit.js
@@ -38,8 +38,8 @@ class Remit {
     this._emitter.on(...args)
   }
 
-  async _connect ({ url, name, exchange }) {
-    const amqpUrl = parseAmqpUrl(url)
+  async _connect ({ url: unparsedUrl, name, exchange }) {
+    const amqpUrl = parseAmqpUrl(unparsedUrl)
     const connectionOptions = generateConnectionOptions(name)
     const { hostname } = url.parse(amqpUrl)
     connectionOptions.servername = hostname

--- a/lib/Remit.js
+++ b/lib/Remit.js
@@ -6,6 +6,7 @@ const parseAmqpUrl = require('../utils/parseAmqpUrl')
 const generateConnectionOptions = require('../utils/generateConnectionOptions')
 const ChannelPool = require('../utils/ChannelPool')
 const CallableWrapper = require('../utils/CallableWrapper')
+const throwAsException = require('../utils/throwAsException')
 const Endpoint = require('./Endpoint')
 const Listener = require('./Listener')
 const Request = require('./Request')
@@ -27,7 +28,7 @@ class Remit {
     this._options.url = options.url || process.env.REMIT_URL || 'amqp://localhost'
 
     this._emitter = new EventEmitter()
-    this._connection = this._connect(this._options)
+    this._connection = this._connect(this._options).catch(throwAsException)
     this._workers = ChannelPool(this._connection)
 
     // TODO make this better


### PR DESCRIPTION
PR for #63. Shouldn't require any extra user action. Tests would be good, but not super-crucial as we'd need a permanent testing ground to connect to.

Tested against a secure Compose.io instance and working. Uses [their guide](https://help.compose.com/docs/rabbitmq-connecting-to-rabbitmq#section-node-and-rabbitmq) for reference.