### PR TITLE
fix(requests): set message expiration to match given timeout

### DIFF
--- a/lib/Request.js
+++ b/lib/Request.js
@@ -107,6 +107,12 @@ class Request extends CallableInstance {
       message.priority = parsedOptions.priority
     }
 
+    let timeout = 30000
+    let givenTimeout = Number(parsedOptions.timeout)
+    if (!isNaN(givenTimeout)) timeout = givenTimeout
+
+    if (timeout) message.expiration = timeout
+
     let parsedData
     let eventData = data
 
@@ -135,10 +141,6 @@ class Request extends CallableInstance {
     })
 
     this._emitter.emit('sent', event)
-
-    let timeout = 30000
-    let givenTimeout = Number(parsedOptions.timeout)
-    if (!isNaN(givenTimeout)) timeout = givenTimeout
 
     if (timeout) {
       this._setTimer(messageId, timeout, event)

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -142,6 +142,7 @@ describe('Request', function () {
     })
 
     it('should return fallback if timing out and fallback set')
+    it('should expire from queue after same time as timeout')
     it('should send NULL if given unparsable data')
   })
 })


### PR DESCRIPTION
Closes #75.

There's just a test stub being added here rather than a full test; to be a full test, there would need to be an existing endpoint queue which was not _active_, but we currently have no way to do that.

There's a PR for pausing in the pipeline (#73), but until then we can't really test it.