### PR TITLE
messages which are emitted should default to being persistent

### DIFF
--- a/lib/Emitter.js
+++ b/lib/Emitter.js
@@ -82,7 +82,12 @@ class Emitter extends CallableInstance {
         originId: originId,
         bubbleId: bubbleId,
         fromBubbleId: bubbleId
-      }
+      },
+      persistent: true
+    }
+
+    if (parsedOptions.persistent === false) {
+      message.persistent = false
     }
 
     if (parsedOptions.priority) {

--- a/lib/Emitter.js
+++ b/lib/Emitter.js
@@ -86,10 +86,6 @@ class Emitter extends CallableInstance {
       persistent: true
     }
 
-    if (parsedOptions.persistent === false) {
-      message.persistent = false
-    }
-
     if (parsedOptions.priority) {
       if (parsedOptions.priority > 10 || parsedOptions.priority < 0) {
         throw new Error(`Invalid priority "${parsedOptions.priority}" when making request`)


### PR DESCRIPTION
this PR should just flip the default but allow overriding also. http://www.squaremobius.net/amqp.node/channel_api.html#channelpublish

At the moment, whilst queues are persisted and survive a restart its messages do not.

(untested)