### PR TITLE
🚩(listener): add 'subscribe' option, allowing pubsub behaviour

### DIFF
--- a/lib/Listener.js
+++ b/lib/Listener.js
@@ -110,7 +110,7 @@ class Listener {
 
       try {
         consumeResult = await this._consumer.consume(
-          this._options.queue,
+          this._consumerQueueName,
           bubble.bind(this._incoming.bind(this)),
           {
             noAck: false,
@@ -174,17 +174,18 @@ class Listener {
     this._consumer.ack(message)
   }
 
-  async _setup ({ queue, event, prefetch = 48 }) {
+  async _setup ({ queue, event, prefetch = 48, subscribe }) {
     this._starting = true
 
     try {
       const worker = await this._remit._workers.acquire()
+      let ok
 
       try {
-        await worker.assertQueue(queue, {
-          exclusive: false,
-          durable: true,
-          autoDelete: false,
+        ok = await worker.assertQueue(subscribe ? '' : queue, {
+          exclusive: subscribe,
+          durable: !subscribe,
+          autoDelete: subscribe,
           maxPriority: 10
         })
 
@@ -195,6 +196,7 @@ class Listener {
         throw e
       }
 
+      this._consumerQueueName = ok.queue
       const connection = await this._remit._connection
       this._consumer = await connection.createChannel()
       this._consumer.on('error', console.error)
@@ -207,7 +209,7 @@ class Listener {
       }
 
       await this._consumer.bindQueue(
-        queue,
+        this._consumerQueueName,
         this._remit._exchange,
         event
       )


### PR DESCRIPTION
If the `subscribe` option is truthy, create a non-permanent queue to subscribe to emitted events as long as the consumer is alive.

Great for places where you just want usual pubsub behaviour without fucking with service names.

Needs docs and tests.