### PR TITLE
🚩 add the ability to store and watch synced data

### DIFF
--- a/lib/Remit.js
+++ b/lib/Remit.js
@@ -11,6 +11,7 @@ const Endpoint = require('./Endpoint')
 const Listener = require('./Listener')
 const Request = require('./Request')
 const Emitter = require('./Emitter')
+const Watch = require('./Watch')
 
 class Remit {
   constructor (options = {}) {
@@ -18,6 +19,7 @@ class Remit {
     this.emit = new CallableWrapper(this, Emitter)
     this.endpoint = new CallableWrapper(this, Endpoint)
     this.request = new CallableWrapper(this, Request)
+    this.watch = new CallableWrapper(this, Watch)
 
     this.version = packageJson.version
 

--- a/lib/Watch.js
+++ b/lib/Watch.js
@@ -76,8 +76,6 @@ class Watch {
       if (ack) this._consumer.nack(message, false, true)
     }
 
-    console.log('wowoowow')
-
     this._state = data
 
     if (message.properties.headers) {

--- a/lib/Watch.js
+++ b/lib/Watch.js
@@ -61,7 +61,7 @@ class Watch {
     return this._started
   }
 
-  async _incoming (message, ack) {
+  async _incoming (ack, message) {
     if (!message) {
       await throwAsException(new Error('Consumer cancelled unexpectedly; this was most probably done via RabbitMQ\'s management panel'))
     }
@@ -70,9 +70,10 @@ class Watch {
       var data = JSON.parse(message.content.toString())
     } catch (e) {
       console.error(e)
-      if (ack) this._consumer.nack(message, false, true)
 
       return
+    } finally {
+      if (ack) this._consumer.nack(message, false, true)
     }
 
     console.log('wowoowow')
@@ -127,9 +128,9 @@ class Watch {
             consumerQueue = queue
 
             return worker.bindQueue(
-            consumerQueue,
-            this._remit._exchange,
-            event
+              consumerQueue,
+              this._remit._exchange,
+              event
             )
           })
         ])
@@ -146,11 +147,9 @@ class Watch {
         throwAsException(new Error('Consumer died - this is most likely due to the RabbitMQ connection dying'))
       })
 
-      const boundRun = bubble.bind(this._incoming.bind(this))
-
       await this._consumer.consume(
         consumerQueue,
-        boundRun,
+        bubble.bind(this._incoming.bind(this, false)),
         {
           noAck: true,
           exclusive: true
@@ -158,7 +157,10 @@ class Watch {
       )
 
       const msg = await this._consumer.get(queue)
-      if (msg) boundRun(msg)
+
+      if (msg) {
+        bubble.bind(this._incoming.bind(this, true))(msg)
+      }
 
       delete this._starting
 

--- a/lib/Watch.js
+++ b/lib/Watch.js
@@ -43,7 +43,6 @@ class Watch {
     if (!this._options) this._options = {}
     this._options.event = opts.event || this._options.event
     this._options.queue = `remit::data::${this._options.event}`
-    this._options.consumerQueue = `remit::data-consumer::${this._options.event}`
 
     return this
   }
@@ -99,8 +98,9 @@ class Watch {
     }
   }
 
-  async _setup ({ queue, consumerQueue, event }) {
+  async _setup ({ queue, event }) {
     this._starting = true
+    let consumerQueue
 
     try {
       const worker = await this._remit._workers.acquire()
@@ -118,16 +118,20 @@ class Watch {
             event
           )),
 
-          worker.assertQueue(consumerQueue, {
+          worker.assertQueue('', {
             exclusive: true,
             durable: false,
             autoDelete: true,
             maxLength: 1
-          }).then(() => worker.bindQueue(
+          }).then(({ queue }) => {
+            consumerQueue = queue
+
+            return worker.bindQueue(
             consumerQueue,
             this._remit._exchange,
             event
-          ))
+            )
+          })
         ])
       } catch (e) {
         this._remit._workers.destroy(worker)

--- a/lib/Watch.js
+++ b/lib/Watch.js
@@ -1,0 +1,169 @@
+const EventEmitter = require('eventemitter3')
+const { ulid } = require('ulid')
+const bubble = require('../utils/bubble')
+const waterfall = require('../utils/asyncWaterfall')
+const parseEvent = require('../utils/parseEvent')
+const handlerWrapper = require('../utils/handlerWrapper')
+const throwAsException = require('../utils/throwAsException')
+
+class Watch {
+  constructor (remit, event, ...handlers) {
+    this._remit = remit
+    this._emitter = new EventEmitter()
+    this._state = undefined
+
+    if (!event) {
+      throw new Error('No event specified when creating a watcher')
+    }
+
+    this.options({ event })
+
+    if (handlers.length) {
+      this.handler(...handlers)
+    }
+  }
+
+  get state () {
+    return this._state
+  }
+
+  handler (...fns) {
+    this._handler = waterfall(...fns.map(handlerWrapper))
+
+    return this
+  }
+
+  on (...args) {
+    this._emitter.on(...args)
+
+    return this
+  }
+
+  options (opts = {}) {
+    if (!this._options) this._options = {}
+    this._options.event = opts.event || this._options.event
+    this._options.queue = `remit::data::${this._options.event}`
+    this._options.consumerQueue = `remit::data-consumer::${this._options.event}`
+
+    return this
+  }
+
+  start () {
+    if (this._started) {
+      return this._started
+    }
+
+    if (!this._handler) {
+      throw new Error('Trying to boot watcher with no handler')
+    }
+
+    this._started = this._setup(this._options)
+
+    return this._started
+  }
+
+  async _incoming (message, ack) {
+    if (!message) {
+      await throwAsException(new Error('Consumer cancelled unexpectedly; this was most probably done via RabbitMQ\'s management panel'))
+    }
+
+    try {
+      var data = JSON.parse(message.content.toString())
+    } catch (e) {
+      console.error(e)
+      if (ack) this._consumer.nack(message, false, true)
+
+      return
+    }
+
+    console.log('wowoowow')
+
+    this._state = data
+
+    if (message.properties.headers) {
+      bubble.set('originId', message.properties.headers.originId)
+      if (!bubble.get('bubbleId')) bubble.set('bubbleId', ulid())
+    }
+
+    const event = parseEvent(message.properties, message.fields, data, {
+      flowType: 'entry',
+      isReceiver: true
+    })
+
+    this._handler(event)
+
+    try {
+      this._emitter.emit('data', event)
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+  async _setup ({ queue, consumerQueue, event }) {
+    this._starting = true
+
+    try {
+      const worker = await this._remit._workers.acquire()
+
+      try {
+        await Promise.all([
+          worker.assertQueue(queue, {
+            exclusive: false,
+            durable: true,
+            autoDelete: false,
+            maxLength: 1
+          }).then(() => worker.bindQueue(
+            queue,
+            this._remit._exchange,
+            event
+          )),
+
+          worker.assertQueue(consumerQueue, {
+            exclusive: true,
+            durable: false,
+            autoDelete: true,
+            maxLength: 1
+          }).then(() => worker.bindQueue(
+            consumerQueue,
+            this._remit._exchange,
+            event
+          ))
+        ])
+      } catch (e) {
+        this._remit._workers.destroy(worker)
+
+        throw e
+      }
+
+      const connection = await this._remit._connection
+      this._consumer = await connection.createChannel()
+      this._consumer.on('error', console.error)
+      this._consumer.on('close', () => {
+        throwAsException(new Error('Consumer died - this is most likely due to the RabbitMQ connection dying'))
+      })
+
+      const boundRun = bubble.bind(this._incoming.bind(this))
+
+      await this._consumer.consume(
+        consumerQueue,
+        boundRun,
+        {
+          noAck: true,
+          exclusive: true
+        }
+      )
+
+      const msg = await this._consumer.get(queue)
+      if (msg) boundRun(msg)
+
+      delete this._starting
+
+      return this
+    } catch (e) {
+      delete this._starting
+      await throwAsException(e)
+    }
+  }
+}
+
+module.exports = Watch


### PR DESCRIPTION
A really interesting little idea.

This adds the ability to use a new `remit.watch` command. It functions similarly to a listener, but is intended for a block of JSON synced between multiple processes.

``` js
// create the watcher
const watcher = remit
  .watch('my.synced.data')
  .handler(({ data }) => {
    console.log('got new data:', data)
  })

watcher.start()

// access the current data set
console.log('current data is:', watcher.state)
```

Multiple processes accessing the same `my.synced.data` there will all receive the same JSON block. To change it, any of the processes can send an emission to `my.synced.data` and all of the watchers will receive the update.

Testing it out in a tiny little environment with servers spinning up and down. It's a super-interesting little idea, though not sure how viable/useful it is in the real world.